### PR TITLE
Admin template labels

### DIFF
--- a/app/routes/articles.php
+++ b/app/routes/articles.php
@@ -7,14 +7,17 @@ class articles_route {
 
     public function page_init() {
           auth::check();
-          $s = Slim::getInstance();
-          $s->view()->setData('section', 'articles');
-          $s->view()->setData('label', 'article');
-          $s->view()->setData('prefix', $this->prefix);
     }
 
     public function post_init() {
           auth::check();
+    }
+
+    public static function get_view_data() {
+        $s = Slim::getInstance();
+        $s->view()->setData('section', 'Articles');
+        $s->view()->setData('label', 'Article');
+        $s->view()->setData('prefix', 'article');
     }
 
     function __construct() {
@@ -22,10 +25,12 @@ class articles_route {
         $prefix = $this->prefix;
 
         $s->get($this->base, $this->page_init(), function () use ($s) {
+            articles_route::get_view_data();
             return $s->render('articles/list.tpl', array('action_name' => 'List', 'articles' => $s->db->articles->find()));
         })->name($prefix);
 
         $s->get($this->base . 'create', $this->page_init(), function () use ($s) {
+            articles_route::get_view_data();
             foreach($s->db->users->find() as $author) {
                 $authors[$author['_id']] = $author['display_name'];
             }
@@ -55,6 +60,7 @@ class articles_route {
         })->name($prefix . '_create_post');
 
         $s->get($this->base . '(:_id)/edit', $this->page_init(), function ($_id) use ($s,$prefix) {
+            articles_route::get_view_data();
             foreach($s->db->users->find() as $author) {
                 $authors[$author['_id']] = $author['display_name'];
             }
@@ -74,6 +80,7 @@ class articles_route {
         })->name($prefix . '_delete');
 
         $s->get($this->base . '(:_id)', $this->page_init(), function ($_id) {
+            articles_route::get_view_data();
             echo "Hello, $_id!";
         })->name($prefix . '_view');
     }

--- a/app/routes/articles.php
+++ b/app/routes/articles.php
@@ -13,7 +13,7 @@ class articles_route {
           auth::check();
     }
 
-    public static function get_view_data() {
+    public static function set_view_data() {
         $s = Slim::getInstance();
         $s->view()->setData('section', 'Articles');
         $s->view()->setData('label', 'Article');
@@ -25,12 +25,12 @@ class articles_route {
         $prefix = $this->prefix;
 
         $s->get($this->base, $this->page_init(), function () use ($s) {
-            articles_route::get_view_data();
+            articles_route::set_view_data();
             return $s->render('articles/list.tpl', array('action_name' => 'List', 'articles' => $s->db->articles->find()));
         })->name($prefix);
 
         $s->get($this->base . 'create', $this->page_init(), function () use ($s) {
-            articles_route::get_view_data();
+            articles_route::set_view_data();
             foreach($s->db->users->find() as $author) {
                 $authors[$author['_id']] = $author['display_name'];
             }
@@ -60,7 +60,7 @@ class articles_route {
         })->name($prefix . '_create_post');
 
         $s->get($this->base . '(:_id)/edit', $this->page_init(), function ($_id) use ($s,$prefix) {
-            articles_route::get_view_data();
+            articles_route::set_view_data();
             foreach($s->db->users->find() as $author) {
                 $authors[$author['_id']] = $author['display_name'];
             }
@@ -80,7 +80,7 @@ class articles_route {
         })->name($prefix . '_delete');
 
         $s->get($this->base . '(:_id)', $this->page_init(), function ($_id) {
-            articles_route::get_view_data();
+            articles_route::set_view_data();
             echo "Hello, $_id!";
         })->name($prefix . '_view');
     }

--- a/app/routes/users.php
+++ b/app/routes/users.php
@@ -7,25 +7,30 @@ class users_route {
 
     public function page_init() {
           auth::check();
-          $s = Slim::getInstance();
-          $s->view()->setData('section', 'Users');
-          $s->view()->setData('label', 'User');
-          $s->view()->setData('prefix', $this->prefix);
     }
 
     public function post_init() {
           auth::check();
     }
 
+    public static function set_view_data() {
+          $s = Slim::getInstance();
+          $s->view()->setData('section', 'Users');
+          $s->view()->setData('label', 'User');
+          $s->view()->setData('prefix', 'user');
+    }
+
     function __construct() {
         $s = Slim::getInstance();
         $prefix = $this->prefix;
 
-        $s->get($this->base, $this->page_init(), function () use ($s) {
+        $s->get($this->base, $this->page_init(), function () use ($s, $prefix) {
+            users_route::set_view_data();
             return $s->render('users/list.tpl', array('action_name' => 'List', 'users' => $s->db->users->find()));
         })->name($prefix);
 
-        $s->get($this->base . 'create', $this->page_init(), function () use ($s) {
+        $s->get($this->base . 'create', $this->page_init(), function () use ($s, $prefix) {
+            users_route::set_view_data();
             return $s->render('users/edit.tpl', array('action_name' => 'Create', 'user' => (array) new User()));
         })->name($prefix . '_create');
 
@@ -38,6 +43,7 @@ class users_route {
         })->name($prefix . '_create_post');
 
         $s->get($this->base . '(:_id)/edit', $this->page_init(), function ($_id) use ($s,$prefix) {
+            users_route::set_view_data();
             $user = $s->db->users->findOne(array( '_id' => $_id));
             if (empty($user)) { $s->notFound(); }
             return $s->render('users/edit.tpl', array( 'form_action' => $s->urlFor($prefix . "_create"), 'action_name' 	=> 	'Edit', 'user' => $user));
@@ -49,6 +55,7 @@ class users_route {
         })->name($prefix . '_delete');
 
         $s->get($this->base . '(:_id)', $this->page_init(), function ($_id) {
+            users_route::set_view_data();
             echo "Hello, $_id!";
         })->name($prefix . '_view');
     }


### PR DESCRIPTION
I noticed a bug with the labels in the admin template - eventually it turned out to be to do with when the additional functions are called when you register a route.  Every route was overwriting the settings on the view (since there's only one slim instance).  I've changed this all up to set the variables we need from a static function inside each route function.  Hope it makes sense.
